### PR TITLE
Turn pipefail option off to not change behaviour beyond the function scope

### DIFF
--- a/10/root/usr/share/container-scripts/postgresql/common.sh
+++ b/10/root/usr/share/container-scripts/postgresql/common.sh
@@ -260,6 +260,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()

--- a/12/root/usr/share/container-scripts/postgresql/common.sh
+++ b/12/root/usr/share/container-scripts/postgresql/common.sh
@@ -260,6 +260,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()

--- a/13/root/usr/share/container-scripts/postgresql/common.sh
+++ b/13/root/usr/share/container-scripts/postgresql/common.sh
@@ -260,6 +260,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()

--- a/14/root/usr/share/container-scripts/postgresql/common.sh
+++ b/14/root/usr/share/container-scripts/postgresql/common.sh
@@ -260,6 +260,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()

--- a/15/root/usr/share/container-scripts/postgresql/common.sh
+++ b/15/root/usr/share/container-scripts/postgresql/common.sh
@@ -260,6 +260,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()

--- a/src/root/usr/share/container-scripts/postgresql/common.sh
+++ b/src/root/usr/share/container-scripts/postgresql/common.sh
@@ -261,6 +261,7 @@ migrate_db ()
         pg_dumpall -h "$POSTGRESQL_MIGRATION_REMOTE_HOST" \
             | grep -v '^CREATE ROLE postgres;'
     ) | psql
+    set +o pipefail
 }
 
 function set_pgdata ()


### PR DESCRIPTION
Otherwise we would change behavior way too much, possibly in scripts that are out of our control